### PR TITLE
console: move the cursor relative to origin

### DIFF
--- a/lib/console.js
+++ b/lib/console.js
@@ -97,7 +97,6 @@ Console.prototype.aggregate = function(item){
 Console.prototype.update = function(){
   var len = this.items.length;
   var percent = sum(this.items, 'progress') / len | 0;
-  this.cursor.up(1);
   this.log(0, len + ' items', percent + '%');
 };
 


### PR DESCRIPTION
Instead of clearing the screen upon upload, and calling `cursor.goto()`
with absolute screen positions, use `cursor.up()` and `cursor.down()` to
move relative to the current location on the terminal.

Fixes #40.
