### PR TITLE
Make URLs visible when using dark themes

### DIFF
--- a/lib/console.js
+++ b/lib/console.js
@@ -194,9 +194,10 @@ Console.prototype.log = function(y, key, str){
     .write(sprintf('%25s', key))
     .fg.reset()
     .write(' : ')
-    .fg.brightBlack()
+    .fg.hex('#8c8c8c')
     .write(str)
     .fg.reset()
+    .bg.reset()
     .write('\n');
 
   if (this.cursor.enabled) {


### PR DESCRIPTION
If using a dark theme in the terminal, the link of the newly-uploaded
file isn't visible. This changes the text to a grey that is visible for
both light and dark themes.

Fixes #49.

<img width="634" alt="screencapture-20160223t112825" src="https://cloud.githubusercontent.com/assets/110755/13260324/99d86a96-da20-11e5-9550-7b4ae1af2ac7.png">
<img width="574" alt="screencapture-20160223t112816" src="https://cloud.githubusercontent.com/assets/110755/13260325/99e43952-da20-11e5-8510-45fd0c310720.png">
<img width="577" alt="screencapture-20160223t112755" src="https://cloud.githubusercontent.com/assets/110755/13260326/99e7025e-da20-11e5-9020-b896c12d59aa.png">
<img width="567" alt="screencapture-20160223t112743" src="https://cloud.githubusercontent.com/assets/110755/13260327/99e8968c-da20-11e5-92c5-d44134b55b89.png">
