### PR TITLE
Fix #53: drop head usage, bump cloudup-client dependency to 0.3.3

### DIFF
--- a/bin/up
+++ b/bin/up
@@ -10,7 +10,6 @@ var pkg = require('../package');
 var thumb = require('osthumb');
 var copy = require('cliparoo');
 var path = require('path');
-var head = require('head');
 var basename = path.basename;
 var uid = require('uid2');
 var up = require('..');
@@ -150,12 +149,15 @@ stream.save(function(err){
  */
 
 function textual(file) {
-  var buf = head(file, 24 * 1024);
-
+  var fd = fs.openSync(path, 'r');
+  var size = fs.statSync(path);
+  var len = Math.min(size, 24 * 1024)
+  var buffer = new Buffer(len);
+  fs.readSync(fd, buffer, 0, len, 0);
+  fs.closeSync(fd);
   for (var i = 0; i < buf.length; i++) {
     if (0 == buf[i]) return false;
   }
-
   return true;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "up",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "cloudup command-line executable",
   "keywords": [
     "cloudup",
@@ -13,12 +13,11 @@
     "ansi": "~0.3.0",
     "bytes": "~2.1.0",
     "cliparoo": "1.0.0",
-    "cloudup-client": "0.3.2",
+    "cloudup-client": "~0.3.2",
     "co": "3.1.0",
     "co-prompt": "1.0.0",
     "commander": "1.3.2",
     "gnode": "0.1.1",
-    "head": "~1.0.0",
     "is-code": "~1.1.0",
     "max-component": "~1.0.0",
     "ms": "0.7.1",


### PR DESCRIPTION
Please review/merge https://github.com/Automattic/cloudup-client/pull/42 before that one.