### PR TITLE
Fix critical open alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "is-code": "~1.1.0",
     "max-component": "~1.0.0",
     "ms": "0.7.1",
-    "open": "0.0.5",
+    "open": "6.0.0",
     "osenv": "~0.1.1",
     "osthumb": "0.0.1",
     "printf": "0.2.2",
@@ -30,6 +30,9 @@
     "term-list": "0.2.1",
     "thunkify": "2.1.2",
     "uid2": "0.0.3"
+  },
+  "overrides": {
+    "form-data": "2.5.5"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
## Summary
- Bumps open from 0.0.5 to 6.0.0 to clear the critical command injection advisory.
- Adds a form-data override for the vulnerable cloudup-client transitive path found during temporary audit validation.

## Testing
- Temporary package-lock-only install for audit validation
- npm audit --audit-level=critical
- JavaScript syntax checks
- git diff --check